### PR TITLE
Adds search syntax help text

### DIFF
--- a/x-pack/plugins/global_search_bar/public/components/search_bar.tsx
+++ b/x-pack/plugins/global_search_bar/public/components/search_bar.tsx
@@ -6,6 +6,7 @@
 
 import {
   EuiBadge,
+  EuiCode,
   EuiFlexGroup,
   EuiFlexItem,
   EuiHeaderSectionItemButton,
@@ -290,42 +291,58 @@ export function SearchBar({
         <EuiText color="subdued" size="xs">
           <EuiFlexGroup
             alignItems="center"
-            justifyContent="flexEnd"
+            justifyContent="spaceBetween"
             gutterSize="s"
             responsive={false}
             wrap
           >
-            <FormattedMessage
-              id="xpack.globalSearchBar.searchBar.shortcutDescription.shortcutDetail"
-              defaultMessage="{shortcutDescription}{commandDescription}"
-              values={{
-                shortcutDescription: (
-                  <EuiFlexItem grow={false}>
-                    <FormattedMessage
-                      id="xpack.globalSearchBar.searchBar.shortcutDescription.shortcutInstructionDescription"
-                      defaultMessage="Shortcut"
-                    />
-                  </EuiFlexItem>
-                ),
-                commandDescription: (
-                  <EuiFlexItem grow={false}>
-                    <EuiBadge>
-                      {isMac ? (
-                        <FormattedMessage
-                          id="xpack.globalSearchBar.searchBar.shortcutDescription.macCommandDescription"
-                          defaultMessage="Command + /"
-                        />
-                      ) : (
-                        <FormattedMessage
-                          id="xpack.globalSearchBar.searchBar.shortcutDescription.windowsCommandDescription"
-                          defaultMessage="Control + /"
-                        />
-                      )}
-                    </EuiBadge>
-                  </EuiFlexItem>
-                ),
-              }}
-            />
+            <EuiFlexItem>
+              <p style={{ marginBottom: 0 }}>
+                <FormattedMessage
+                  id="xpack.globalSearchBar.searchBar.helpText.helpTextPrefix"
+                  defaultMessage="Filter by"
+                />
+                &nbsp;
+                <EuiCode>type:</EuiCode>&nbsp;
+                <FormattedMessage
+                  id="xpack.globalSearchBar.searchBar.helpText.helpTextConjunction"
+                  defaultMessage="or"
+                />
+                &nbsp;
+                <EuiCode>tag:</EuiCode>
+              </p>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <p style={{ marginBottom: 0 }}>
+                <FormattedMessage
+                  id="xpack.globalSearchBar.searchBar.shortcutDescription.shortcutDetail"
+                  defaultMessage="{shortcutDescription} {commandDescription}"
+                  values={{
+                    shortcutDescription: (
+                      <FormattedMessage
+                        id="xpack.globalSearchBar.searchBar.shortcutDescription.shortcutInstructionDescription"
+                        defaultMessage="Shortcut"
+                      />
+                    ),
+                    commandDescription: (
+                      <EuiCode>
+                        {isMac ? (
+                          <FormattedMessage
+                            id="xpack.globalSearchBar.searchBar.shortcutDescription.macCommandDescription"
+                            defaultMessage="Command + /"
+                          />
+                        ) : (
+                          <FormattedMessage
+                            id="xpack.globalSearchBar.searchBar.shortcutDescription.windowsCommandDescription"
+                            defaultMessage="Control + /"
+                          />
+                        )}
+                      </EuiCode>
+                    ),
+                  }}
+                />
+              </p>
+            </EuiFlexItem>
           </EuiFlexGroup>
         </EuiText>
       }


### PR DESCRIPTION
Let me know what you think. I'm thinking of this as a potentially short-term fix until we have the nicer 'suggestion' result that Michael designed.

- Adds help text regarding search syntax
- Simplifies footer markup
- Matches shortcut style to help text style

<img width="684" alt="Screen Shot 2020-11-19 at 5 12 29 PM" src="https://user-images.githubusercontent.com/446285/99736522-2507fa80-2a8c-11eb-81b7-41bc505646b5.png">
